### PR TITLE
Feat: 챗봇 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ repositories {
 }
 
 dependencies {
+    implementation platform('org.springframework.ai:spring-ai-bom:1.1.4')
+    implementation 'org.springframework.ai:spring-ai-starter-model-google-genai'
+    implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 //    implementation 'org.springframework.boot:spring-boot-starter-security'
 //    implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client'

--- a/src/main/java/com/catchtable/chatbot/config/ChatClientConfig.java
+++ b/src/main/java/com/catchtable/chatbot/config/ChatClientConfig.java
@@ -1,0 +1,14 @@
+package com.catchtable.chatbot.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ChatClientConfig {
+
+    @Bean
+    public ChatClient chatClient(ChatClient.Builder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/com/catchtable/chatbot/controller/ChatbotController.java
+++ b/src/main/java/com/catchtable/chatbot/controller/ChatbotController.java
@@ -1,0 +1,48 @@
+package com.catchtable.chatbot.controller;
+
+import java.util.List;
+
+import com.catchtable.chatbot.dto.create.ChatMessageRequest;
+import com.catchtable.chatbot.dto.create.ChatMessageResponse;
+import com.catchtable.chatbot.dto.read.ChatMessageListResponse;
+import com.catchtable.chatbot.service.ChatbotService;
+import com.catchtable.global.common.ApiResponse;
+import com.catchtable.global.common.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/chat")
+@RequiredArgsConstructor
+public class ChatbotController {
+
+    private final ChatbotService chatbotService;
+
+    @PostMapping("/messages")
+    public ResponseEntity<ApiResponse<ChatMessageResponse>> sendMessage(
+            @RequestParam Long userId,
+            @Valid @RequestBody ChatMessageRequest request
+    ) {
+        ChatMessageResponse responseData = chatbotService.sendMessage(userId, request);
+        return ResponseEntity
+                .status(SuccessCode.CHAT_MESSAGE_SENT.getHttpStatus())
+                .body(ApiResponse.success(SuccessCode.CHAT_MESSAGE_SENT, responseData));
+    }
+
+    @GetMapping("/messages")
+    public ResponseEntity<ApiResponse<List<ChatMessageListResponse>>> getMessages(
+            @RequestParam Long userId
+    ) {
+        List<ChatMessageListResponse> responseData = chatbotService.getMessages(userId);
+        return ResponseEntity
+                .status(SuccessCode.CHAT_MESSAGE_LIST_OK.getHttpStatus())
+                .body(ApiResponse.success(SuccessCode.CHAT_MESSAGE_LIST_OK, responseData));
+    }
+}

--- a/src/main/java/com/catchtable/chatbot/dto/create/ChatMessageRequest.java
+++ b/src/main/java/com/catchtable/chatbot/dto/create/ChatMessageRequest.java
@@ -1,0 +1,12 @@
+package com.catchtable.chatbot.dto.create;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record ChatMessageRequest(
+
+        @Schema(example = "모수 용산점 3월 22일 18시 3명 예약해줘")
+        @NotBlank(message = "메시지는 필수입니다.")
+        String message
+) {
+}

--- a/src/main/java/com/catchtable/chatbot/dto/create/ChatMessageResponse.java
+++ b/src/main/java/com/catchtable/chatbot/dto/create/ChatMessageResponse.java
@@ -1,0 +1,7 @@
+package com.catchtable.chatbot.dto.create;
+
+public record ChatMessageResponse(
+        Long messageId,
+        String reply
+) {
+}

--- a/src/main/java/com/catchtable/chatbot/dto/read/ChatMessageListResponse.java
+++ b/src/main/java/com/catchtable/chatbot/dto/read/ChatMessageListResponse.java
@@ -1,0 +1,13 @@
+package com.catchtable.chatbot.dto.read;
+
+import com.catchtable.chatbot.entity.MessageRole;
+
+import java.time.LocalDateTime;
+
+public record ChatMessageListResponse(
+        Long messageId,
+        MessageRole role,
+        String content,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/catchtable/chatbot/entity/ChatMessage.java
+++ b/src/main/java/com/catchtable/chatbot/entity/ChatMessage.java
@@ -1,0 +1,54 @@
+package com.catchtable.chatbot.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private ChatSession chatSession;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MessageRole role;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    @Builder
+    public ChatMessage(ChatSession chatSession, MessageRole role, String content) {
+        this.chatSession = chatSession;
+        this.role = role;
+        this.content = content;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/catchtable/chatbot/entity/ChatSession.java
+++ b/src/main/java/com/catchtable/chatbot/entity/ChatSession.java
@@ -1,0 +1,61 @@
+package com.catchtable.chatbot.entity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.catchtable.user.entity.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatSession {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToMany(mappedBy = "chatSession", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatMessage> messages = new ArrayList<>();
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public ChatSession(User user) {
+        this.user = user;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/catchtable/chatbot/entity/MessageRole.java
+++ b/src/main/java/com/catchtable/chatbot/entity/MessageRole.java
@@ -1,0 +1,6 @@
+package com.catchtable.chatbot.entity;
+
+public enum MessageRole {
+    USER,
+    ASSISTANT
+}

--- a/src/main/java/com/catchtable/chatbot/repository/ChatMessageRepository.java
+++ b/src/main/java/com/catchtable/chatbot/repository/ChatMessageRepository.java
@@ -1,0 +1,16 @@
+package com.catchtable.chatbot.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.catchtable.chatbot.entity.ChatMessage;
+import com.catchtable.chatbot.entity.ChatSession;
+import com.catchtable.chatbot.entity.MessageRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    List<ChatMessage> findByChatSessionOrderByCreatedAtAsc(ChatSession chatSession);
+
+    long countByChatSessionAndRoleAndCreatedAtAfter(ChatSession chatSession, MessageRole role, LocalDateTime after);
+}

--- a/src/main/java/com/catchtable/chatbot/repository/ChatSessionRepository.java
+++ b/src/main/java/com/catchtable/chatbot/repository/ChatSessionRepository.java
@@ -1,0 +1,12 @@
+package com.catchtable.chatbot.repository;
+
+import java.util.Optional;
+
+import com.catchtable.chatbot.entity.ChatSession;
+import com.catchtable.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
+
+    Optional<ChatSession> findByUser(User user);
+}

--- a/src/main/java/com/catchtable/chatbot/service/ChatbotService.java
+++ b/src/main/java/com/catchtable/chatbot/service/ChatbotService.java
@@ -1,0 +1,123 @@
+package com.catchtable.chatbot.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.catchtable.chatbot.dto.create.ChatMessageRequest;
+import com.catchtable.chatbot.dto.create.ChatMessageResponse;
+import com.catchtable.chatbot.dto.read.ChatMessageListResponse;
+import com.catchtable.chatbot.entity.ChatMessage;
+import com.catchtable.chatbot.entity.ChatSession;
+import com.catchtable.chatbot.entity.MessageRole;
+import com.catchtable.chatbot.repository.ChatMessageRepository;
+import com.catchtable.chatbot.repository.ChatSessionRepository;
+import com.catchtable.global.exception.CustomException;
+import com.catchtable.global.exception.ErrorCode;
+import com.catchtable.user.entity.User;
+import com.catchtable.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatbotService {
+
+    private static final int DAILY_MESSAGE_LIMIT = 100;
+
+    private static final String SYSTEM_PROMPT =
+            "너는 캐치테이블 레스토랑 예약 플랫폼의 AI 도우미야. "
+            + "사용자의 예약, 매장 검색, 맛집 추천 요청을 도와줘. "
+            + "한국어로 친절하게 답변해.";
+
+    private final ChatClient chatClient;
+    private final ChatSessionRepository chatSessionRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ChatMessageResponse sendMessage(Long userId, ChatMessageRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 세션이 없으면 자동 생성
+        ChatSession session = chatSessionRepository.findByUser(user)
+                .orElseGet(() -> chatSessionRepository.save(
+                        ChatSession.builder().user(user).build()));
+
+        // 일일 메시지 제한 확인
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        long dailyCount = chatMessageRepository.countByChatSessionAndRoleAndCreatedAtAfter(
+                session, MessageRole.USER, startOfDay);
+        if (dailyCount >= DAILY_MESSAGE_LIMIT) {
+            throw new CustomException(ErrorCode.CHAT_DAILY_LIMIT_EXCEEDED);
+        }
+
+        // 사용자 메시지 저장
+        ChatMessage userMessage = ChatMessage.builder()
+                .chatSession(session)
+                .role(MessageRole.USER)
+                .content(request.message())
+                .build();
+        chatMessageRepository.save(userMessage);
+
+        // 대화 이력 조회 → Gemini에 전달
+        List<ChatMessage> history = chatMessageRepository.findByChatSessionOrderByCreatedAtAsc(session);
+        String reply = callAi(history);
+
+        // AI 응답 저장
+        ChatMessage assistantMessage = ChatMessage.builder()
+                .chatSession(session)
+                .role(MessageRole.ASSISTANT)
+                .content(reply)
+                .build();
+        ChatMessage saved = chatMessageRepository.save(assistantMessage);
+
+        return new ChatMessageResponse(saved.getId(), reply);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatMessageListResponse> getMessages(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        ChatSession session = chatSessionRepository.findByUser(user)
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_SESSION_NOT_FOUND));
+
+        return chatMessageRepository.findByChatSessionOrderByCreatedAtAsc(session).stream()
+                .map(message -> new ChatMessageListResponse(
+                        message.getId(),
+                        message.getRole(),
+                        message.getContent(),
+                        message.getCreatedAt()))
+                .toList();
+    }
+
+    private String callAi(List<ChatMessage> history) {
+        List<Message> messages = new java.util.ArrayList<>();
+        messages.add(new SystemMessage(SYSTEM_PROMPT));
+
+        for (ChatMessage msg : history) {
+            if (msg.getRole() == MessageRole.USER) {
+                messages.add(new UserMessage(msg.getContent()));
+            } else {
+                messages.add(new AssistantMessage(msg.getContent()));
+            }
+        }
+
+        try {
+            return chatClient.prompt(new Prompt(messages))
+                    .call()
+                    .content();
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.CHAT_AI_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/catchtable/global/common/SuccessCode.java
+++ b/src/main/java/com/catchtable/global/common/SuccessCode.java
@@ -43,7 +43,11 @@ public enum SuccessCode implements ResponseCode {
 
     // Remain
     REMAIN_CREATE_SUCCESS(HttpStatus.CREATED, "예약 목록이 성공적으로 생성되었습니다."),
-    REMAIN_LOOKUP_SUCCESS(HttpStatus.OK, "예약 가능 시간 조회가 완료되었습니다.");
+    REMAIN_LOOKUP_SUCCESS(HttpStatus.OK, "예약 가능 시간 조회가 완료되었습니다."),
+
+    // Chat
+    CHAT_MESSAGE_SENT(HttpStatus.OK, "메시지가 전송되었습니다."),
+    CHAT_MESSAGE_LIST_OK(HttpStatus.OK, "채팅 메시지 목록을 조회했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/catchtable/global/exception/ErrorCode.java
+++ b/src/main/java/com/catchtable/global/exception/ErrorCode.java
@@ -54,7 +54,13 @@ public enum ErrorCode implements ResponseCode {
     // Remain
     REMAIN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예약 시간대입니다."),
     REMAIN_EXHAUSTED(HttpStatus.BAD_REQUEST, "해당 시간대의 예약이 마감되었습니다."),
-    OPTIMISTIC_LOCK_CONFLICT(HttpStatus.CONFLICT, "이미 다른 사용자가 예약하여 마감되었습니다. 다시 시도해주세요.");
+    OPTIMISTIC_LOCK_CONFLICT(HttpStatus.CONFLICT, "이미 다른 사용자가 예약하여 마감되었습니다. 다시 시도해주세요."),
+
+    // Chat
+    CHAT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 채팅 세션입니다."),
+    CHAT_SESSION_NOT_OWNER(HttpStatus.FORBIDDEN, "본인의 채팅 세션만 접근할 수 있습니다."),
+    CHAT_DAILY_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "일일 메시지 제한(100회)을 초과했습니다."),
+    CHAT_AI_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI 응답 생성 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📢 기능 설명

- 로그인 ~ 로그아웃까지 하나의 대화 생성 및 유지
- 첫 메시지 전송 시 세션 자동 생성
- 이전 대화 맥락을 DB에 저장(맥락을 유지하면 AI에 전달)
- 일일 메시지 제한: 사용자당 100회
- 분당 제한: Gemini API 자체 제한(15회)
