### PR TITLE
feat: 사용자 방문 확정 API 추가

### DIFF
--- a/src/main/java/com/catchtable/global/exception/ErrorCode.java
+++ b/src/main/java/com/catchtable/global/exception/ErrorCode.java
@@ -62,6 +62,7 @@ public enum ErrorCode implements ResponseCode {
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다."),
     NOT_RESERVATION_OWNER(HttpStatus.FORBIDDEN, "본인의 예약만 접근할 수 있습니다."),
     ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 예약입니다."),
+    NOT_VISITABLE_STATUS(HttpStatus.BAD_REQUEST, "이미 방문 완료 처리되었습니다."),
 
     // Remain
     REMAIN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예약 시간대입니다."),

--- a/src/main/java/com/catchtable/reservation/controller/ReservationController.java
+++ b/src/main/java/com/catchtable/reservation/controller/ReservationController.java
@@ -80,4 +80,15 @@ public class ReservationController {
                 .status(SuccessCode.RESERVATION_UPDATE_SUCCESS.getHttpStatus())
                 .body(ApiResponse.success(SuccessCode.RESERVATION_UPDATE_SUCCESS, responseData));
     }
+
+    @PatchMapping("/{reservationId}/visit")
+    public ResponseEntity<ApiResponse<Void>> markAsVisited(
+            @PathVariable Long reservationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        reservationService.markAsVisited(reservationId, userDetails.getUserId());
+        return ResponseEntity
+                .status(SuccessCode.RESERVATION_UPDATE_SUCCESS.getHttpStatus())
+                .body(ApiResponse.success(SuccessCode.RESERVATION_UPDATE_SUCCESS));
+    }
 }

--- a/src/main/java/com/catchtable/reservation/service/ReservationService.java
+++ b/src/main/java/com/catchtable/reservation/service/ReservationService.java
@@ -205,7 +205,7 @@ public class ReservationService {
         reservation.validateOwner(userId);
 
         if (reservation.getStatus() != ReservationStatus.CONFIRMED) {
-            throw new CustomException(ErrorCode.ALREADY_CANCELED);
+            throw new CustomException(ErrorCode.NOT_VISITABLE_STATUS);
         }
 
         reservation.changeStatus(ReservationStatus.VISITED);

--- a/src/main/java/com/catchtable/reservation/service/ReservationService.java
+++ b/src/main/java/com/catchtable/reservation/service/ReservationService.java
@@ -193,6 +193,33 @@ public class ReservationService {
         }
     }
 
+    /**
+     * 사용자가 직접 "방문 확정" 버튼을 눌러 예약을 VISITED 상태로 전환한다.
+     * CONFIRMED 상태에서만 호출 가능. 호출 후 ReservationVisitedEvent 발행으로 알림이 자동 발송된다.
+     */
+    @Transactional
+    public void markAsVisited(Long reservationId, Long userId) {
+        Reservation reservation = reservationRepository.findByIdWithUserAndStoreRemainAndStore(reservationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
+
+        reservation.validateOwner(userId);
+
+        if (reservation.getStatus() != ReservationStatus.CONFIRMED) {
+            throw new CustomException(ErrorCode.ALREADY_CANCELED);
+        }
+
+        reservation.changeStatus(ReservationStatus.VISITED);
+
+        StoreRemain storeRemain = reservation.getStoreRemain();
+        eventPublisher.publishEvent(new ReservationVisitedEvent(
+                reservation.getId(),
+                reservation.getUser().getId(),
+                storeRemain.getStore().getStoreName(),
+                storeRemain.getRemainDate().toString(),
+                storeRemain.getRemainTime().toString()
+        ));
+    }
+
     // ============================================================
     // Internal core (알림 발행 X — 호출자가 알림 정책 결정)
     // ============================================================


### PR DESCRIPTION
- PATCH /api/v1/reservations/{id}/visit 전용 엔드포인트 신설
- markAsVisited 서비스 메서드 추가 (CONFIRMED → VISITED 전환)
- 본인 예약 검증 + CONFIRMED 상태 검증 포함

## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{53}
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?