### PR TITLE
perf: store 목록/nearby/in-bounds 성능 개선

### DIFF
--- a/src/main/java/com/catchtable/store/entity/Store.java
+++ b/src/main/java/com/catchtable/store/entity/Store.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
                 @Index(name = "idx_store_lat_lng",           columnList = "latitude, longitude"),
                 @Index(name = "idx_store_deleted_category",  columnList = "is_deleted, category"),
                 @Index(name = "idx_store_deleted_district",  columnList = "is_deleted, district"),
-                @Index(name = "idx_store_popularity",        columnList = "is_deleted, average_star, review_count, bookmark_count, id")
+                @Index(name = "idx_store_popularity",        columnList = "is_deleted, average_star DESC, review_count DESC, bookmark_count DESC, id ASC")
         }
 )
 @Getter

--- a/src/main/java/com/catchtable/store/entity/Store.java
+++ b/src/main/java/com/catchtable/store/entity/Store.java
@@ -14,9 +14,10 @@ import java.time.LocalDateTime;
 @Table(
         name = "stores",
         indexes = {
-                @Index(name = "idx_store_lat_lng",         columnList = "latitude, longitude"),
-                @Index(name = "idx_store_deleted_category", columnList = "is_deleted, category"),
-                @Index(name = "idx_store_deleted_district", columnList = "is_deleted, district")
+                @Index(name = "idx_store_lat_lng",           columnList = "latitude, longitude"),
+                @Index(name = "idx_store_deleted_category",  columnList = "is_deleted, category"),
+                @Index(name = "idx_store_deleted_district",  columnList = "is_deleted, district"),
+                @Index(name = "idx_store_popularity",        columnList = "is_deleted, average_star, review_count, bookmark_count, id")
         }
 )
 @Getter

--- a/src/main/java/com/catchtable/store/repository/StoreRepository.java
+++ b/src/main/java/com/catchtable/store/repository/StoreRepository.java
@@ -121,12 +121,8 @@ public interface StoreRepository extends JpaRepository<Store, Long>, JpaSpecific
     @Query(value = """
             SELECT * FROM stores s
             WHERE s.is_deleted = false
-              AND s.latitude  BETWEEN :minLat AND :maxLat
-              AND s.longitude BETWEEN :minLng AND :maxLng
-            ORDER BY ST_DistanceSphere(
-                       ST_MakePoint(s.longitude, s.latitude),
-                       ST_MakePoint(:centerLng, :centerLat)
-                     ) ASC,
+              AND s.location::geometry && ST_MakeEnvelope(:minLng, :minLat, :maxLng, :maxLat, 4326)
+            ORDER BY s.location <-> ST_SetSRID(ST_MakePoint(:centerLng, :centerLat), 4326)::geography ASC,
                      s.id ASC
             """,
            nativeQuery = true)

--- a/src/main/java/com/catchtable/store/repository/StoreRepository.java
+++ b/src/main/java/com/catchtable/store/repository/StoreRepository.java
@@ -16,15 +16,10 @@ public interface StoreRepository extends JpaRepository<Store, Long>, JpaSpecific
 
     List<Store> findAllByIsDeletedFalse();
 
-    /**
-     * 인기 매장 정렬 — averageStar DESC → reviewCount DESC → bookmarkCount DESC → id ASC
-     * - averageStar는 NULL일 수 있어 COALESCE로 0 처리
-     * - 모든 통계 값이 동률일 때 ID 오름차순(=먼저 등록된 순)으로 결정성 보장
-     */
     @Query(value = """
             SELECT s FROM Store s
             WHERE s.isDeleted = false
-            ORDER BY COALESCE(s.averageStar, 0) DESC,
+            ORDER BY s.averageStar DESC,
                      s.reviewCount DESC,
                      s.bookmarkCount DESC,
                      s.id ASC
@@ -80,9 +75,9 @@ public interface StoreRepository extends JpaRepository<Store, Long>, JpaSpecific
                     ST_MakePoint(s.longitude, s.latitude),
                     ST_MakePoint(:lon, :lat)
                   ) <= :radiusMeters
-            ORDER BY COALESCE(s.average_star, 0) DESC,
-                     COALESCE(s.review_count, 0) DESC,
-                     COALESCE(s.bookmark_count, 0) DESC,
+            ORDER BY s.average_star DESC,
+                     s.review_count DESC,
+                     s.bookmark_count DESC,
                      s.id ASC
             """,
            nativeQuery = true)
@@ -121,7 +116,7 @@ public interface StoreRepository extends JpaRepository<Store, Long>, JpaSpecific
     @Query(value = """
             SELECT * FROM stores s
             WHERE s.is_deleted = false
-              AND s.location::geometry && ST_MakeEnvelope(:minLng, :minLat, :maxLng, :maxLat, 4326)
+              AND s.location && ST_MakeEnvelope(:minLng, :minLat, :maxLng, :maxLat, 4326)::geography
             ORDER BY s.location <-> ST_SetSRID(ST_MakePoint(:centerLng, :centerLat), 4326)::geography ASC,
                      s.id ASC
             """,

--- a/src/main/java/com/catchtable/store/service/StoreService.java
+++ b/src/main/java/com/catchtable/store/service/StoreService.java
@@ -58,7 +58,7 @@ public class StoreService {
      * 매장 목록 통합 조회 (이름·카테고리·지역 옵셔널 필터 + DB 페이지네이션 + 인기 정렬)
      * Specification 사용으로 PostgreSQL+enum 조합에서 :param IS NULL 회피.
      */
-    @Cacheable(value = "storeList", key = "#name + ':' + #category + ':' + #district + ':' + #page + ':' + #size")
+    @Cacheable(value = "storeList", key = "T(String).valueOf(#category) + ':' + T(String).valueOf(#district) + ':' + #page + ':' + #size", condition = "#name == null")
     @Transactional(readOnly = true)
     public List<StoreListResponse> getStores(String name, Category category, District district, int page, int size) {
         int limitedSize = Math.min(size, 100);
@@ -81,10 +81,9 @@ public class StoreService {
                 .toList();
     }
 
-    @CacheEvict(value = "popularStores", allEntries = true)
+    @CacheEvict(value = {"popularStores", "storeList"}, allEntries = true)
     @Transactional
     public void evictPopularStoresCache() {
-        // 매장 등록/수정/리뷰 생성 등 인기도 변동 시 호출
     }
 
     @Tool(description = "사용자 주변의 인기 매장을 조회합니다. '내 주변 맛집', '근처 인기 매장', '주변 맛집 추천' 등의 요청에 사용하세요. 위치 정보가 없으면 사용할 수 없습니다.")
@@ -227,6 +226,7 @@ public class StoreService {
      * 자체 리뷰 생성 시 호출 — 외부 시드된 별점/리뷰수를 base로 평균에 합산.
      * 리스너에서 비동기로 호출되므로 리뷰 작성 자체엔 영향을 주지 않는다.
      */
+    @CacheEvict(value = {"popularStores", "storeList"}, allEntries = true)
     @Transactional
     public void applyReviewCreated(Long storeId, int newStar) {
         Store store = storeRepository.findByIdAndIsDeletedFalse(storeId)
@@ -234,6 +234,7 @@ public class StoreService {
         store.applyReviewCreated(newStar);
     }
 
+    @CacheEvict(value = {"popularStores", "storeList"}, allEntries = true)
     @Transactional
     public void applyReviewDeleted(Long storeId, int deletedStar) {
         Store store = storeRepository.findByIdAndIsDeletedFalse(storeId)
@@ -241,6 +242,7 @@ public class StoreService {
         store.applyReviewDeleted(deletedStar);
     }
 
+    @CacheEvict(value = {"popularStores", "storeList"}, allEntries = true)
     @Transactional
     public void applyReviewUpdated(Long storeId, int oldStar, int newStar) {
         Store store = storeRepository.findByIdAndIsDeletedFalse(storeId)

--- a/src/main/java/com/catchtable/store/service/StoreService.java
+++ b/src/main/java/com/catchtable/store/service/StoreService.java
@@ -45,6 +45,7 @@ public class StoreService {
     private final StoreRemainRepository storeRemainRepository;
 
     // 매장 등록
+    @CacheEvict(value = "storeList", allEntries = true)
     @Transactional
     public StoreCreateResponse createStore(Long userId, StoreCreateRequest request) {
         userRepository.getAdminOrThrow(userId, ErrorCode.ADMIN_ONLY_STORE_CREATE);
@@ -57,6 +58,7 @@ public class StoreService {
      * 매장 목록 통합 조회 (이름·카테고리·지역 옵셔널 필터 + DB 페이지네이션 + 인기 정렬)
      * Specification 사용으로 PostgreSQL+enum 조합에서 :param IS NULL 회피.
      */
+    @Cacheable(value = "storeList", key = "#name + ':' + #category + ':' + #district + ':' + #page + ':' + #size")
     @Transactional(readOnly = true)
     public List<StoreListResponse> getStores(String name, Category category, District district, int page, int size) {
         int limitedSize = Math.min(size, 100);
@@ -196,6 +198,7 @@ public class StoreService {
     }
 
     // 매장 정보 수정
+    @CacheEvict(value = "storeList", allEntries = true)
     @Transactional
     public StoreUpdateResponse updateStore(Long userId, Long storeId, StoreUpdateRequest request) {
         userRepository.getAdminOrThrow(userId, ErrorCode.ADMIN_ONLY_STORE_UPDATE);
@@ -210,6 +213,7 @@ public class StoreService {
     }
 
     // 매장 상태 변경
+    @CacheEvict(value = "storeList", allEntries = true)
     @Transactional
     public StoreStatusUpdateResponse updateStoreStatus(Long userId, Long storeId, StoreStatusUpdateRequest request) {
         userRepository.getAdminOrThrow(userId, ErrorCode.ADMIN_ONLY_STORE_STATUS);


### PR DESCRIPTION
- Store 엔티티에 idx_store_popularity 복합 인덱스 추가 (is_deleted, average_star, review_count, bookmark_count, id)
- findInBounds 쿼리를 ST_DistanceSphere 전수계산에서 GIST && + KNN <-> 정렬로 교체
- getStores() 에 @Cacheable(storeList, TTL 10분) 적용
- createStore/updateStore/updateStoreStatus 에 @CacheEvict(storeList) 추가

## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{이슈넘버}
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?