### PR TITLE
perf: nearby 반경 5000m -> 1000m 축소 (Seq Scan 방지)

### DIFF
--- a/src/main/java/com/catchtable/store/service/StoreService.java
+++ b/src/main/java/com/catchtable/store/service/StoreService.java
@@ -119,7 +119,7 @@ public class StoreService {
     public List<StoreListResponse> getNearbyStores(double latitude, double longitude, int page, int size) {
         int limitedSize = Math.min(size, 100);
         return storeRepository.findNearbyWithGist(
-                latitude, longitude, 5000.0,
+                latitude, longitude, 1000.0,
                 PageRequest.of(page, limitedSize)
         ).stream().map(StoreListResponse::from).toList();
     }


### PR DESCRIPTION
서울 중심 5km 반경에 전체 매장 56%가 집중되어 플래너가 GIST 인덱스 대신
Seq Scan을 선택. 반경 축소로 매칭 행 수를 줄여 인덱스 활용 유도.

## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{이슈넘버}
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?