### PR TITLE
fix: k6 테스트 버그 수정 및 메모리 한도 상향

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,7 +16,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 600M
+          memory: 1000M
         reservations:
           memory: 400M
     healthcheck:
@@ -85,7 +85,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 350M
+          memory: 800M
     restart: unless-stopped
     networks:
       - catchtable-net
@@ -102,7 +102,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 200M
+          memory: 300M
     restart: unless-stopped
     networks:
       - catchtable-net
@@ -121,7 +121,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 100M
+          memory: 200M
     restart: unless-stopped
     networks:
       - catchtable-net
@@ -144,7 +144,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 200M
+          memory: 300M
     restart: unless-stopped
     networks:
       - catchtable-net
@@ -171,7 +171,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 100M
+          memory: 200M
     restart: unless-stopped
     networks:
       - catchtable-net
@@ -216,7 +216,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 400M
+          memory: 600M
 
     restart: unless-stopped
     networks:

--- a/k6/05-store-list.js
+++ b/k6/05-store-list.js
@@ -61,7 +61,7 @@ export const options = {
 };
 
 const CATEGORIES = ['KOREAN', 'JAPANESE', 'CHINESE', 'WESTERN', 'CAFE'];
-const DISTRICTS  = ['강남구', '마포구', '종로구', '용산구', '성동구'];
+const DISTRICTS  = ['GANGNAM', 'MAPO', 'JONGNO', 'YONGSAN', 'SEONGDONG'];
 
 export default function () {
   const isSpike        = exec.scenario.name === 'event_spike';
@@ -87,6 +87,7 @@ export default function () {
       '목록 조회 200': (r) => r.status === 200,
       '응답 body 존재': (r) => r.body && r.body.length > 0,
     });
+    if (!ok) console.log(`[ERROR] status=${res.status} url=${url} body=${res.body?.substring(0, 200)}`);
     errorRate.add(!ok);
   });
 

--- a/k6/06-store-nearby.js
+++ b/k6/06-store-nearby.js
@@ -86,7 +86,7 @@ export default function () {
   group(`근처 매장 조회 (nearby) - ${loc.name}`, () => {
     const res = http.get(
       `${BASE_URL}/api/v1/stores/nearby?latitude=${lat}&longitude=${lng}&page=0&size=10`,
-      { headers: HEADERS_JSON, timeout: '15s' },
+      { headers: HEADERS_JSON, timeout: '15s', tags: { name: 'GET_nearby' } },
     );
     nearbyDuration.add(res.timings.duration);
     record(res.timings.duration);
@@ -104,7 +104,7 @@ export default function () {
       `?minLat=${loc.minLat}&maxLat=${loc.maxLat}` +
       `&minLng=${loc.minLng}&maxLng=${loc.maxLng}` +
       `&centerLat=${lat}&centerLng=${lng}&limit=50`;
-    const res = http.get(url, { headers: HEADERS_JSON, timeout: '15s' });
+    const res = http.get(url, { headers: HEADERS_JSON, timeout: '15s', tags: { name: 'GET_in_bounds' } });
     inBoundsDuration.add(res.timings.duration);
     record(res.timings.duration);
     if (res.timings.duration >= 15000 || res.status === 0) timeoutCount.add(1);


### PR DESCRIPTION
- 05-store-list: DISTRICTS 한글 → 영문 enum 값으로 수정 (에러율 100% 원인)
- 06-store-nearby: HTTP 요청에 고정 name 태그 추가 (Prometheus cardinality 폭발 방지)
- docker-compose.prod.yml: 부하테스트 중 OOM 방지를 위한 컨테이너 메모리 한도 상향 (app 600M→1000M, prometheus 350M→800M, loki/grafana/redis/promtail/kafka 상향)

## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{이슈넘버}
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?