### PR TITLE
fix: CAFE → DESSERT enum 수정, nearby 반경 3000m로 조정

### DIFF
--- a/k6/05-store-list.js
+++ b/k6/05-store-list.js
@@ -60,7 +60,7 @@ export const options = {
   },
 };
 
-const CATEGORIES = ['KOREAN', 'JAPANESE', 'CHINESE', 'WESTERN', 'CAFE'];
+const CATEGORIES = ['KOREAN', 'JAPANESE', 'CHINESE', 'WESTERN', 'DESSERT'];
 const DISTRICTS  = ['GANGNAM', 'MAPO', 'JONGNO', 'YONGSAN', 'SEONGDONG'];
 
 export default function () {

--- a/src/main/java/com/catchtable/store/service/StoreService.java
+++ b/src/main/java/com/catchtable/store/service/StoreService.java
@@ -119,7 +119,7 @@ public class StoreService {
     public List<StoreListResponse> getNearbyStores(double latitude, double longitude, int page, int size) {
         int limitedSize = Math.min(size, 100);
         return storeRepository.findNearbyWithGist(
-                latitude, longitude, 1000.0,
+                latitude, longitude, 3000.0,
                 PageRequest.of(page, limitedSize)
         ).stream().map(StoreListResponse::from).toList();
     }


### PR DESCRIPTION
- 05-store-list: CATEGORIES의 CAFE를 실제 enum 값인 DESSERT로 수정
- StoreService: getNearbyStores 반경 1000m → 3000m 복원

## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{이슈넘버}
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?